### PR TITLE
Show a placeholder image with an image between events

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -74,7 +74,7 @@ assignEvents events model =
     completed = events |> List.filter (withStatus Completed)
     maybeNext = events |> List.filter (withStatus Live) |> List.head
   in 
-    { model | next = maybeNext, pastEvents = completed }
+    { model | next = Loaded maybeNext, pastEvents = completed }
 
 -----------------
 -- Api queries --

--- a/src/elm/Models.elm
+++ b/src/elm/Models.elm
@@ -5,8 +5,10 @@ import Random
 import Json.Decode as Json exposing ((:=))
 import Json.Decode.Extra as JsonX
 
+type Resource val = Loading | Loaded val
+
 type alias Model = 
-  { next : Maybe Event
+  { next : Resource (Maybe Event)
   , pastEvents : List Event
   , sponsors : List Sponsor
   , board : List BoardMember
@@ -18,7 +20,7 @@ type alias Model =
   }
 
 emptyModel = 
-  { next = Nothing
+  { next = Loading
   , board = []
   , pastEvents = []
   , sponsors = []

--- a/src/elm/Views.elm
+++ b/src/elm/Views.elm
@@ -156,7 +156,7 @@ pastEvents events =
       ] ++ content)
 
 
-nextEvent =
+nextEvent resource =
   let 
     mkParagraphs txt = txt |> String.split "\n" |> List.map (single p)
     showEvent e =
@@ -185,7 +185,7 @@ nextEvent =
             ]
         ]
 
-    noEvent =
+    workingOnIt =
       section [class "next-event section -empty"]
         [
           header  [] [text "Next Event"]
@@ -202,7 +202,10 @@ nextEvent =
         , loading
         ]
 
-  in Maybe.map showEvent >> Maybe.withDefault loadingEvents
+  in 
+      case resource of
+        Loading -> loadingEvents
+        Loaded next -> next |> Maybe.map showEvent |> Maybe.withDefault workingOnIt
 
 menuOptions =
   [ aBlank [title "Open Event Brite page", href "http://www.eventbrite.com/org/1699161450"] [text "Events"]


### PR DESCRIPTION
Fixes #25 

* Added type to represent a resource that is loading `Loading | Loaded`
* Modified view to show only the spinner when `Loading`
* Modified view to handle the next event and if it is `Nothing` show the image with the message _working on it_