### PR TITLE
Added function to process tweet urls; added models and decoders

### DIFF
--- a/src/assets/scss/_component.twitter.scss
+++ b/src/assets/scss/_component.twitter.scss
@@ -12,7 +12,7 @@
   
   a {
     text-decoration: none;
-    color: inherit;
+    color: darken($greenish, 20%);
   }
 }
 

--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -183,5 +183,3 @@ tweetDecoder =
         (field "created_at" JsonX.date)
         (field "user" userDecoder)
         (field "entity" entityDecoder)
-
-        

--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -163,13 +163,25 @@ tweetDecoder =
         (field "name" Json.string)
         (field "url"  Json.string)
         (field "profile_image_url" Json.string)
+    
+    entityDecoder =
+      Json.map
+        Tweets.TweetEntity
+        (field "urls" (list urlDecoder))
+    
+    urlDecoder =
+      Json.map
+        Tweets.TweetUrl
+        (field "url" Json.string)    
 
   in
     Json.at ["tweets"]
     <| Json.list
-    <| Json.map3
+    <| Json.map4
         Tweets.Tweet
         (field "text" Json.string)
         (field "created_at" JsonX.date)
         (field "user" userDecoder)
+        (field "entity" entityDecoder)
 
+        

--- a/src/elm/components/Tweets.elm
+++ b/src/elm/components/Tweets.elm
@@ -88,7 +88,7 @@ view resource =
       case resource of
         Nothing                 -> errorLoading
         Just (Resource.Loading) -> [loading]
-        Just (Resource.Loaded tweets) -> tweets |> List.take 5 |> List.map mkTweet   
+        Just (Resource.Loaded tweets) -> tweets |> List.take 5 |> List.map mkTweet
   in
     div [class "list-n-twitter"]
       [ article [class "subscribe"]


### PR DESCRIPTION
If a Tweet object entity has URLs, this converts them into <a> hyperlinks.

Fixes #50 

(open to suggestions/improvements to my Elm code :) )